### PR TITLE
Bump v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb_node"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "dmp",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb_node"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]
@@ -12,7 +12,7 @@ napi = { version = "2", features = ["async", "serde-json"] }
 napi-derive = "2"
 serde = "1.0.188"
 serde_json = "1.0.105"
-surrealdb = { version = "1.0.0-beta.11", features = ["kv-mem"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem"] }
 
 [build-dependencies]
 napi-build = "2.0.1"
@@ -24,12 +24,12 @@ rocksdb = ["surrealdb/kv-rocksdb"]
 lto = true
 
 [target.x86_64-pc-windows-msvc.dependencies]
-surrealdb = { version = "1.0.0-beta.10", features = ["kv-mem", "kv-rocksdb"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem", "kv-rocksdb"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
-surrealdb = { version = "1.0.0-beta.10", features = ["kv-mem", "kv-rocksdb"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem", "kv-rocksdb"] }
 [target.aarch64-linux-android.dependencies]
-surrealdb = { version = "1.0.0-beta.10", features = ["kv-mem", "kv-rocksdb"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem", "kv-rocksdb"] }
 [target.armv7-linux-androideabi.dependencies]
-surrealdb = { version = "1.0.0-beta.10", features = ["kv-mem", "kv-rocksdb"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem", "kv-rocksdb"] }
 # [target.aarch64-apple-darwin.dependencies]
 # surrealdb = { version = "1.0.0-beta.10", features = ["kv-mem", "kv-rocksdb"] }

--- a/npm/android-arm-eabi/package.json
+++ b/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-android-arm-eabi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "android"
   ],

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-android-arm64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "android"
   ],

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-darwin-arm64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-universal/package.json
+++ b/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-darwin-universal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-darwin-x64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "darwin"
   ],

--- a/npm/freebsd-x64/package.json
+++ b/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-freebsd-x64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "freebsd"
   ],

--- a/npm/linux-arm-gnueabihf/package.json
+++ b/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-linux-arm-gnueabihf",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-linux-arm64-gnu",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-linux-arm64-musl",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-linux-x64-gnu",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-linux-x64-musl",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-win32-arm64-msvc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "win32"
   ],

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-win32-ia32-msvc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node-win32-x64-msvc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "os": [
     "win32"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealdb.node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealdb.node",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "ava": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb.node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Raphael Darley",
     "email": "raphael.darley@surrealdb.com"


### PR DESCRIPTION
While SurrealDB was already at version 1.0.0 in the cargo lockfile, I made the version explicit in the `Cargo.toml` file too