### PR TITLE
add close() to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@
 export class Surreal {
   constructor()
   connect(endpoint: string, opts?: Record<string, unknown>): Promise<void>
+  close(): Promise<void>
   use(value: { namespace?: string; database?: string }): Promise<void>
   set(key: string, value: unknown): Promise<void>
   unset(key: string): Promise<void>


### PR DESCRIPTION
close function as described in the documentation here > https://docs.surrealdb.com/docs/integration/sdks/nodejs#close  not added to type definition